### PR TITLE
Added from sys import exit to fix retraining model

### DIFF
--- a/keras_segmentation/models/_pspnet_2.py
+++ b/keras_segmentation/models/_pspnet_2.py
@@ -1,7 +1,7 @@
 # This code is proveded by Vladkryvoruchko and small modifications done by me .
 
 from math import ceil
-
+from sys import exit
 from keras import layers
 from keras.layers import Conv2D, MaxPooling2D, AveragePooling2D
 from keras.layers import BatchNormalization, Activation, Input, Dropout, \


### PR DESCRIPTION
Would previously get the following error with re-training:
```
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-13-4866e8dd5365> in <module>()
     16 new_model = keras_segmentation.models.pspnet.pspnet_50(n_classes=model_config["n_classes"],
     17                                                        input_height=model_config["input_height"],
---> 18                                                        input_width=model_config["input_width"])
     19 
     20 transfer_weights(pretrained_model, new_model) # transfer weights from pre-trained model to your model

3 frames
/content/image-segmentation-keras/keras_segmentation/models/_pspnet_2.py in interp_block(prev_layer, level, feature_map_shape, input_shape)
    216         print("Pooling parameters for input shape ",
    217               input_shape, " are not defined.")
--> 218         exit(1)
    219 
    220     names = [

NameError: name 'exit' is not defined
```

And according to [this](https://stackoverflow.com/questions/45066518/nameerror-name-exit-is-not-defined), this should be a straightforward fix.