### PR TITLE
Add keras and opencv to requirements.txt for pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ h5py
 tqdm
 keras
 opencv-python
+tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 numpy
 h5py
 tqdm
+keras
+opencv-python


### PR DESCRIPTION
I noticed this during an install today. Thought I'd add the dependencies.