### PR TITLE
Fixed image resize for fresh tensorflow & keras

### DIFF
--- a/keras_segmentation/models/_pspnet_2.py
+++ b/keras_segmentation/models/_pspnet_2.py
@@ -34,7 +34,11 @@ class Interp(layers.Layer):
 
     def call(self, inputs, **kwargs):
         new_height, new_width = self.new_size
-        resized = tf.image.resize(inputs, [new_height, new_width])
+        try:
+            resized = tf.image.resize(inputs, [new_height, new_width])
+        except AttributeError:
+            resized = tf.image.resize_images(inputs, [new_height, new_width],
+                                             align_corners=True)
         return resized
 
     def compute_output_shape(self, input_shape):

--- a/keras_segmentation/models/_pspnet_2.py
+++ b/keras_segmentation/models/_pspnet_2.py
@@ -34,8 +34,7 @@ class Interp(layers.Layer):
 
     def call(self, inputs, **kwargs):
         new_height, new_width = self.new_size
-        resized = tf.image.resize_images(inputs, [new_height, new_width],
-                                         align_corners=True)
+        resized = tf.image.resize(inputs, [new_height, new_width])
         return resized
 
     def compute_output_shape(self, input_shape):


### PR DESCRIPTION
Followed steps from README, got AttributeError on
`model = pspnet_50_ADE_20K()`
There is no function resize_images, replaced it to resize (it helped - model sucessfuly loaded and predicted my test images).