### PR TITLE
sort input images to return them in a predictable way

### DIFF
--- a/keras_segmentation/predict.py
+++ b/keras_segmentation/predict.py
@@ -177,6 +177,7 @@ def predict_multiple(model=None, inps=None, inp_dir=None, out_dir=None,
         inps = glob.glob(os.path.join(inp_dir, "*.jpg")) + glob.glob(
             os.path.join(inp_dir, "*.png")) + \
             glob.glob(os.path.join(inp_dir, "*.jpeg"))
+        inps = sorted(inps)
 
     assert type(inps) is list
 


### PR DESCRIPTION
If we use the predict_multiple, the list returned from this method is not sorted in any predictable way. 