### PR TITLE
use cv2.INTER_NEAREST for interpolation

### DIFF
--- a/keras_segmentation/predict.py
+++ b/keras_segmentation/predict.py
@@ -72,7 +72,7 @@ def get_legends(class_names, colors=class_colors):
 def overlay_seg_image(inp_img, seg_img):
     orininal_h = inp_img.shape[0]
     orininal_w = inp_img.shape[1]
-    seg_img = cv2.resize(seg_img, (orininal_w, orininal_h))
+    seg_img = cv2.resize(seg_img, (orininal_w, orininal_h), interpolation=cv2.INTER_NEAREST)
 
     fused_img = (inp_img/2 + seg_img/2).astype('uint8')
     return fused_img
@@ -102,12 +102,12 @@ def visualize_segmentation(seg_arr, inp_img=None, n_classes=None,
     seg_img = get_colored_segmentation_image(seg_arr, n_classes, colors=colors)
 
     if inp_img is not None:
-        orininal_h = inp_img.shape[0]
-        orininal_w = inp_img.shape[1]
-        seg_img = cv2.resize(seg_img, (orininal_w, orininal_h))
+        original_h = inp_img.shape[0]
+        original_w = inp_img.shape[1]
+        seg_img = cv2.resize(seg_img, (original_w, original_h), interpolation=cv2.INTER_NEAREST)
 
     if (prediction_height is not None) and (prediction_width is not None):
-        seg_img = cv2.resize(seg_img, (prediction_width, prediction_height))
+        seg_img = cv2.resize(seg_img, (prediction_width, prediction_height), interpolation=cv2.INTER_NEAREST)
         if inp_img is not None:
             inp_img = cv2.resize(inp_img,
                                  (prediction_width, prediction_height))


### PR DESCRIPTION
The default interpolation method `cv2.INTER_LINEAR` used by the `resize` method introduces additional colors due to its smoothing, making it impossible to extract correct sub-sets from the image itself (e.g., when post-processed by another process). This can be avoided by using `cv2.INTER_NEAREST` for interpolation instead.