### PR TITLE
Remove unnecessary requirement on mobilenet width and height.

### DIFF
--- a/keras_segmentation/models/mobilenet.py
+++ b/keras_segmentation/models/mobilenet.py
@@ -65,9 +65,6 @@ def get_mobilenet_encoder(input_height=224, input_width=224,
             'channels_last'), "Currently only channels last mode is supported"
     assert (IMAGE_ORDERING ==
             'channels_last'), "Currently only channels last mode is supported"
-    assert (input_height == 224), \
-        "For mobilenet , 224 input_height is supported "
-    assert (input_width == 224), "For mobilenet , 224 width is supported "
 
     assert input_height % 32 == 0
     assert input_width % 32 == 0

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -26,7 +26,7 @@ def test_models():
     n_c = 100
 
     models = [ ( "unet_mini" , 124 , 156   )  , ( "vgg_unet" , 224 , 224*2   ) , 
-        ( 'resnet50_pspnet', 192*2 , 192*3 ) , ( 'mobilenet_unet', 224 , 224 ),( 'segnet', 224 , 224*2 ),( 'vgg_segnet', 224 , 224*2 ) ,( 'fcn_32', 224 , 224*2 ) ,( 'fcn_8_vgg', 224 , 224*2 )   ]
+        ( 'resnet50_pspnet', 192*2 , 192*3 ) , ( 'mobilenet_unet', 224 , 224 ), ( 'mobilenet_unet', 224+32 , 224+32 ),( 'segnet', 224 , 224*2 ),( 'vgg_segnet', 224 , 224*2 ) ,( 'fcn_32', 224 , 224*2 ) ,( 'fcn_8_vgg', 224 , 224*2 )   ]
 
     for model_name  , h , w in models:
         m = all_models.model_from_name[model_name]( n_c, input_height=h, input_width=w)


### PR DESCRIPTION
The requirement for width % 32 == 0 and height % 32 == 0 is enough. No need to restrict the input shape to 224, 224.