### PR TITLE
Compatibility with TensorFlow 2.4.1

### DIFF
--- a/keras_segmentation/predict.py
+++ b/keras_segmentation/predict.py
@@ -19,10 +19,8 @@ random.seed(DATA_LOADER_SEED)
 
 
 def model_from_checkpoint_path(checkpoints_path):
-
     from .models.all_models import model_from_name
-    assert (os.path.isfile(checkpoints_path+"_config.json")
-            ), "Checkpoint not found."
+    assert (os.path.isfile(os.path.join(checkpoints_path, "_config.json"))), "Checkpoint not found."
     model_config = json.loads(
         open(checkpoints_path+"_config.json", "r").read())
     latest_weights = find_latest_checkpoint(checkpoints_path)

--- a/keras_segmentation/train.py
+++ b/keras_segmentation/train.py
@@ -6,16 +6,16 @@ from .data_utils.data_loader import image_segmentation_generator, \
 import six
 from keras.callbacks import Callback
 from keras.callbacks import ModelCheckpoint
-import tensorflow as tf
 import glob
 import sys
+
 
 def find_latest_checkpoint(checkpoints_path, fail_safe=True):
 
     # This is legacy code, there should always be a "checkpoint" file in your directory
 
     def get_epoch_number_from_path(path):
-        return path.replace(checkpoints_path, "").strip(".")
+        return os.path.basename(path).replace(".index", "").strip(".")
 
     # Get all matching files
     all_checkpoint_files = glob.glob(checkpoints_path + ".*")
@@ -40,6 +40,7 @@ def find_latest_checkpoint(checkpoints_path, fail_safe=True):
                                   int(get_epoch_number_from_path(f)))
 
     return latest_epoch_checkpoint
+
 
 def masked_categorical_crossentropy(gt, pr):
     from keras.losses import categorical_crossentropy


### PR DESCRIPTION
* Under TF 2, the output for the first checkpoint is `.00001.index`  and `.00001.data-00000-of-00001` rather than `.0`. `get_epoch_number_from_path` now strips path using `os.path.basename` and the `.index` suffix to properly return the number of the checkpoint.

* `model_from_checkpoint_path` now uses `os.path.join` to avoid having to supply a trailing slash for the model directory.